### PR TITLE
Support copilot.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ https://github.com/yuki-yano/ddc-copilot
 
 ## Required
 
-### copilot.vim
+### copilot.vim or copilot.lua
 
 https://github.com/github/copilot.vim
+
+https://github.com/zbirenbaum/copilot.lua
 
 ### denops.vim
 
@@ -32,6 +34,11 @@ call ddc#custom#patch_global('sourceOptions', #{
       \     mark: 'copilot',
       \     matchers: [],
       \     minAutoCompleteLength: 0,
+      \   }
+      \ })
+call ddc#custom#patch_global('sourceParams', #{
+      \   copilot: #{
+      \     copilot: 'vim',
       \   }
       \ })
 ```

--- a/doc/ddc-source-copilot.txt
+++ b/doc/ddc-source-copilot.txt
@@ -24,12 +24,23 @@ https://github.com/yuki-yano/ddc-copilot
 ==============================================================================
 INSTALL                                           *ddc-source-copilot-install*
 
-Please install both "copilot.vim", "ddc.vim" and "denops.vim".
+Please install both "copilot.vim" (or "copilot.lua"), "ddc.vim" and
+"denops.vim".
 
 https://github.com/github/copilot.vim
+https://github.com/zbirenbaum/copilot.lua
 https://github.com/Shougo/ddc.vim
 https://github.com/vim-denops/denops.vim
 
+
+==============================================================================
+PARAMS                                             *ddc-source-copilot-params*
+
+                                            *ddc-source-copilot-param-copilot*
+copilot		('vim'|'lua')
+		Types of Copilot integration to use.
+
+		Default: 'vim'
 
 ==============================================================================
 EXAMPLES                                         *ddc-source-copilot-examples*
@@ -43,6 +54,11 @@ EXAMPLES                                         *ddc-source-copilot-examples*
 	\     matchers: [],
 	\     mark: 'copilot',
 	\     minAutoCompleteLength: 0,
+	\   }
+	\ })
+	call ddc#custom#patch_global('sourceParams', #{
+	\   copilot: #{
+	\     copilot: 'vim',
 	\   }
 	\ })
 <

--- a/lua/ddc/source/copilot.lua
+++ b/lua/ddc/source/copilot.lua
@@ -1,0 +1,84 @@
+local api = require("copilot.api")
+local util = require("copilot.util")
+
+local M = {}
+
+--- Get Copilit client
+--- @return lsp.Client | nil
+local function get_client()
+  for _, client in ipairs(vim.lsp.get_clients({ name = "copilot" })) do
+    if client.name == "copilot" then
+      return client
+    end
+  end
+  return nil
+end
+
+--- Split by line
+--- @param str string
+--- @return string[]
+local function split_line(str)
+  local result = {}
+  for line in string.gmatch(str, "[^\r\n]+") do
+    table.insert(result, line)
+  end
+  return result
+end
+
+--- @class Suggestion
+--- @field displayText string
+--- @field position { character: number; line: number }
+--- @field range { start: { character: number; line: number }; end: { character: number; line: number } }
+--- @field text string
+--- @field uuid string
+
+--- @class CompletionMetaData
+--- @field word string
+
+--- @class CompletionItem
+--- @field word string
+--- @field info string[]
+--- @field user_data CompletionMetaData
+
+--- Format completion item
+--- @param complete_pos number
+--- @return fun(item: Suggestion): CompletionItem
+local function format(complete_pos)
+  return function(item)
+    local indent = string.match(item.text, "^%s*")
+    local info = indent ~= nil
+        and vim.tbl_map(function(line)
+            return string.sub(line, string.len(indent) + 1)
+          end,
+          split_line(item.text)
+        )
+        or item.text
+
+    return {
+      word = string.sub(split_line(item.text)[1], complete_pos + 1),
+      info = info,
+      user_data = {
+        word = item.text,
+      },
+    }
+  end
+end
+
+--- Update completion items
+--- @param name string
+--- @param complete_pos number
+M.update_items = function(name, complete_pos)
+  local client = get_client()
+  if client == nil then
+    return
+  end
+  api.get_completions(client, util.get_doc_params(), function(err, response)
+    if err or not response or not response.completions then
+      return
+    end
+    local completion_items = vim.tbl_map(format(complete_pos), response.completions)
+    vim.fn["ddc#update_items"](name, completion_items)
+  end)
+end
+
+return M

--- a/lua/ddc/source/copilot.lua
+++ b/lua/ddc/source/copilot.lua
@@ -4,59 +4,19 @@ local client = require("copilot.client")
 
 local M = {}
 
---- @class Suggestion
---- @field displayText string
---- @field position { character: number; line: number }
---- @field range { start: { character: number; line: number }; end: { character: number; line: number } }
---- @field text string
---- @field uuid string
-
---- @class CompletionMetaData
---- @field word string
-
---- @class CompletionItem
---- @field word string
---- @field info string[]
---- @field user_data CompletionMetaData
-
---- Format completion item
---- @param complete_pos number
---- @return fun(item: Suggestion): CompletionItem
-local function format(complete_pos)
-  return function(item)
-    local indent = string.match(item.text, "^%s*")
-    local info = indent ~= nil
-        and vim.tbl_map(function(line)
-            return string.sub(line, string.len(indent) + 1)
-          end,
-          vim.split(item.text, "\r?\n")
-        )
-        or item.text
-
-    return {
-      word = string.sub(vim.split(item.text, "\r?\n")[1], complete_pos + 1),
-      info = info,
-      user_data = {
-        word = item.text,
-      },
-    }
-  end
-end
-
 --- Update completion items
 --- @param name string
---- @param complete_pos number
-M.update_items = function(name, complete_pos)
+--- @param lambda_id string
+M.update_items = function(name, lambda_id)
   local c = client.get()
   if c == nil then
     return
   end
   api.get_completions(c, util.get_doc_params(), function(err, response)
-    if err or not response or not response.completions then
+    if err or not response or not response.completions or #response.completions == 0 then
       return
     end
-    local completion_items = vim.tbl_map(format(complete_pos), response.completions)
-    vim.fn["ddc#update_items"](name, completion_items)
+    vim.fn["denops#notify"](name, lambda_id, { response.completions })
   end)
 end
 


### PR DESCRIPTION
## Summary

Add support for [zbirenbaum/copilot.lua](https://github.com/zbirenbaum/copilot.lua).

## Details

Some users are preferring to use [zbirenbaum/copilot.lua](https://github.com/zbirenbaum/copilot.lua) instead of [github/copilot.vim](https://github.com/github/copilot.vim).

There is a source for copilot.lua in [ibuki2003/ddc-source-copilot-lua](https://github.com/ibuki2003/ddc-source-copilot-lua) but it is based on ddc.vim v4.

Users can specify either `vim` or `lua` as the source for the Copilot plugin using the `copilot` parameter.

The default is `vim`, so backwards compatibility is keeped.
